### PR TITLE
support parameterValues override [fromParam(parameter-key)] in Component workloadSettings

### DIFF
--- a/apis/common/utils.go
+++ b/apis/common/utils.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/oam-dev/oam-go-sdk/apis/core.oam.dev/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func matchPattern(value string) (match bool, key string) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		key = strings.TrimSuffix(strings.TrimPrefix(value, "${"), "}")
+		return true, key
+	}
+	return false, ""
+}
+
+func getParamValue(params []v1alpha1.ParameterValue, key string) string {
+	for _, v := range params {
+		if v.Name == key {
+			return v.Value
+		}
+	}
+	return ""
+}
+
+func ExtractFromMap(params []v1alpha1.ParameterValue, values map[string]interface{}) map[string]interface{} {
+	for k, v := range values {
+		switch subVal := v.(type) {
+		case string:
+			match, key := matchPattern(subVal)
+			if match {
+				values[k] = getParamValue(params, key)
+			}
+		case map[string]interface{}:
+			values[k] = ExtractFromMap(params, subVal)
+		}
+	}
+	return values
+}
+
+// ExtractParams will extract param from Pattern "${parameter_key}"
+func ExtractParams(params []v1alpha1.ParameterValue, raw runtime.RawExtension) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	if err := json.Unmarshal(raw.Raw, &values); err != nil {
+		return nil, err
+	}
+	return ExtractFromMap(params, values), nil
+}

--- a/apis/common/utils.go
+++ b/apis/common/utils.go
@@ -10,8 +10,8 @@ import (
 
 func matchPattern(value string) (match bool, key string) {
 	value = strings.TrimSpace(value)
-	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
-		key = strings.TrimSuffix(strings.TrimPrefix(value, "${"), "}")
+	if strings.HasPrefix(value, "[fromParam(") && strings.HasSuffix(value, ")]") {
+		key = strings.TrimSuffix(strings.TrimPrefix(value, "[fromParam("), ")]")
 		return true, key
 	}
 	return false, ""

--- a/apis/common/utils_test.go
+++ b/apis/common/utils_test.go
@@ -18,12 +18,12 @@ func Test_matchPattern(t *testing.T) {
 		expKey   string
 	}{
 		{
-			value:    "${value}",
+			value:    "[fromParam(value)]",
 			expMatch: true,
 			expKey:   "value",
 		},
 		{
-			value:    "${}",
+			value:    "[fromParam()]",
 			expMatch: true,
 			expKey:   "",
 		},
@@ -38,9 +38,9 @@ func Test_matchPattern(t *testing.T) {
 			expKey:   "",
 		},
 		{
-			value:    "${${xxx}}",
+			value:    "[fromParam([fromParam(xxx)])]",
 			expMatch: true,
-			expKey:   "${xxx}",
+			expKey:   "[fromParam(xxx)]",
 		},
 	}
 	for _, ti := range tests {
@@ -97,7 +97,7 @@ func Test_ExtractFromMap(t *testing.T) {
 		{
 			params: params,
 			values: map[string]interface{}{
-				"k1": "${k1}",
+				"k1": "[fromParam(k1)]",
 				"k2": "${",
 			},
 			expValues: map[string]interface{}{
@@ -108,9 +108,9 @@ func Test_ExtractFromMap(t *testing.T) {
 		{
 			params: params,
 			values: map[string]interface{}{
-				"k1": "${k1}",
+				"k1": "[fromParam(k1)]",
 				"k2": map[string]interface{}{
-					"k3": "${k3}",
+					"k3": "[fromParam(k3)]",
 					"k4": 12,
 				},
 			},
@@ -131,13 +131,13 @@ func Test_ExtractFromMap(t *testing.T) {
 
 func TestExtractParams(t *testing.T) {
 	j1, _ := json.Marshal(map[string]interface{}{
-		"k1": "${k1}",
-		"k2": "${",
+		"k1": "[fromParam(k1)]",
+		"k2": "[fromParam(",
 	})
 	j2, _ := json.Marshal(map[string]interface{}{
-		"k1": "${k1}",
+		"k1": "[fromParam(k1)]",
 		"k2": map[string]interface{}{
-			"k3": "${k3}",
+			"k3": "[fromParam(k3)]",
 			"k4": "12",
 		},
 	})
@@ -156,7 +156,7 @@ func TestExtractParams(t *testing.T) {
 			values: runtime.RawExtension{Raw: j1},
 			expValues: map[string]interface{}{
 				"k1": "v1",
-				"k2": "${",
+				"k2": "[fromParam(",
 			},
 		},
 		{

--- a/apis/common/utils_test.go
+++ b/apis/common/utils_test.go
@@ -1,0 +1,179 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/oam-dev/oam-go-sdk/apis/core.oam.dev/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_matchPattern(t *testing.T) {
+	tests := []struct {
+		value    string
+		expMatch bool
+		expKey   string
+	}{
+		{
+			value:    "${value}",
+			expMatch: true,
+			expKey:   "value",
+		},
+		{
+			value:    "${}",
+			expMatch: true,
+			expKey:   "",
+		},
+		{
+			value:    "${",
+			expMatch: false,
+			expKey:   "",
+		},
+		{
+			value:    "{vv}",
+			expMatch: false,
+			expKey:   "",
+		},
+		{
+			value:    "${${xxx}}",
+			expMatch: true,
+			expKey:   "${xxx}",
+		},
+	}
+	for _, ti := range tests {
+		gotMatch, gotKey := matchPattern(ti.value)
+		assert.Equal(t, ti.expMatch, gotMatch)
+		assert.Equal(t, ti.expKey, gotKey)
+	}
+}
+
+func Test_getParamValue(t *testing.T) {
+	params := []v1alpha1.ParameterValue{
+		{Name: "k1", Value: "v1"},
+		{Name: "k2", Value: ""},
+		{Name: "k3", Value: "xxx"},
+	}
+	tests := []struct {
+		params []v1alpha1.ParameterValue
+		key    string
+		value  string
+	}{
+		{
+			params: params,
+			key:    "k1",
+			value:  "v1",
+		},
+		{
+			params: params,
+			key:    "k2",
+			value:  "",
+		},
+		{
+			params: params,
+			key:    "kk",
+			value:  "",
+		},
+	}
+	for _, ti := range tests {
+		gotValue := getParamValue(ti.params, ti.key)
+		assert.Equal(t, ti.value, gotValue)
+	}
+}
+
+func Test_ExtractFromMap(t *testing.T) {
+	params := []v1alpha1.ParameterValue{
+		{Name: "k1", Value: "v1"},
+		{Name: "k2", Value: ""},
+		{Name: "k3", Value: "xxx"},
+	}
+	tests := []struct {
+		params    []v1alpha1.ParameterValue
+		values    map[string]interface{}
+		expValues map[string]interface{}
+	}{
+		{
+			params: params,
+			values: map[string]interface{}{
+				"k1": "${k1}",
+				"k2": "${",
+			},
+			expValues: map[string]interface{}{
+				"k1": "v1",
+				"k2": "${",
+			},
+		},
+		{
+			params: params,
+			values: map[string]interface{}{
+				"k1": "${k1}",
+				"k2": map[string]interface{}{
+					"k3": "${k3}",
+					"k4": 12,
+				},
+			},
+			expValues: map[string]interface{}{
+				"k1": "v1",
+				"k2": map[string]interface{}{
+					"k3": "xxx",
+					"k4": 12,
+				},
+			},
+		},
+	}
+	for _, ti := range tests {
+		gotValue := ExtractFromMap(ti.params, ti.values)
+		assert.Equal(t, ti.expValues, gotValue)
+	}
+}
+
+func TestExtractParams(t *testing.T) {
+	j1, _ := json.Marshal(map[string]interface{}{
+		"k1": "${k1}",
+		"k2": "${",
+	})
+	j2, _ := json.Marshal(map[string]interface{}{
+		"k1": "${k1}",
+		"k2": map[string]interface{}{
+			"k3": "${k3}",
+			"k4": "12",
+		},
+	})
+	params := []v1alpha1.ParameterValue{
+		{Name: "k1", Value: "v1"},
+		{Name: "k2", Value: ""},
+		{Name: "k3", Value: "xxx"},
+	}
+	tests := []struct {
+		params    []v1alpha1.ParameterValue
+		values    runtime.RawExtension
+		expValues map[string]interface{}
+	}{
+		{
+			params: params,
+			values: runtime.RawExtension{Raw: j1},
+			expValues: map[string]interface{}{
+				"k1": "v1",
+				"k2": "${",
+			},
+		},
+		{
+			params: params,
+			values: runtime.RawExtension{Raw: j2},
+			expValues: map[string]interface{}{
+				"k1": "v1",
+				"k2": map[string]interface{}{
+					"k3": "xxx",
+					"k4": "12",
+				},
+			},
+		},
+	}
+	for _, ti := range tests {
+		gotValue, err := ExtractParams(ti.params, ti.values)
+		assert.NoError(t, err)
+		assert.Equal(t, ti.expValues, gotValue)
+	}
+}

--- a/examples/app.yaml
+++ b/examples/app.yaml
@@ -19,11 +19,7 @@ spec:
       traits:
         - name: rollout
           properties:
-            - name: canaryReplicas
-              value: "2"
-            - name: batches
-              value: "2"
-            - name: batchInterval
-              value: "10"
-            - name: instanceInterval
-              value: "1"
+            canaryReplicas: "2"
+            batches: "2"
+            batchInterval: "10"
+            instanceInterval: "1"

--- a/pkg/examples/extendworkload/app.yaml
+++ b/pkg/examples/extendworkload/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.oam.dev/v1alpha1
+kind: ApplicationConfiguration
+metadata:
+  name: example-app
+spec:
+  components:
+    - componentName: example-workload
+      instanceName: demo
+      parameterValues:
+        - name: Type
+          value: demo

--- a/pkg/examples/extendworkload/component.yaml
+++ b/pkg/examples/extendworkload/component.yaml
@@ -10,5 +10,5 @@ spec:
   workloadType: example.com/v1alpha1.ExtentionWorkload
   workloadSettings:
     Protocol: Example
-    Type: ${Type}
+    Type: "[fromParam(Type)]"
     Description: xxx

--- a/pkg/examples/extendworkload/component.yaml
+++ b/pkg/examples/extendworkload/component.yaml
@@ -11,4 +11,3 @@ spec:
   workloadSettings:
     Protocol: Example
     Type: "[fromParam(Type)]"
-    Description: xxx

--- a/pkg/examples/extendworkload/component.yaml
+++ b/pkg/examples/extendworkload/component.yaml
@@ -10,7 +10,5 @@ spec:
   workloadType: example.com/v1alpha1.ExtentionWorkload
   workloadSettings:
     Protocol: Example
-    Type: Performance
+    Type: ${Type}
     Description: xxx
-  expose:
-    - name: exampleOutput

--- a/pkg/examples/extendworkload/main.go
+++ b/pkg/examples/extendworkload/main.go
@@ -76,7 +76,9 @@ func (s *Handler) Handle(ctx *oam.ActionContext, comp runtime.Object, eType oam.
 			fmt.Printf("%s: %s\n", k, v)
 		}
 	}
-	return nil
+	appConfig.Status.Phase = "updated"
+	_, err := s.client.CoreV1alpha1().ApplicationConfigurations(appConfig.Namespace).UpdateStatus(appConfig)
+	return err
 }
 
 func (s *Handler) Id() string {

--- a/pkg/examples/extendworkload/main.go
+++ b/pkg/examples/extendworkload/main.go
@@ -1,10 +1,16 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+
+	"github.com/oam-dev/oam-go-sdk/apis/common"
+
+	"github.com/oam-dev/oam-go-sdk/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"log"
 
 	"github.com/oam-dev/oam-go-sdk/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/oam-go-sdk/pkg/oam"
@@ -31,37 +37,44 @@ func main() {
 	options := ctrl.Options{Scheme: scheme, MetricsBindAddress: metricsAddr}
 	// init
 	oam.InitMgr(ctrl.GetConfigOrDie(), options)
-
+	client, err := versioned.NewForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		log.Fatal("create client err: ", err)
+	}
 	// register workloadtpye & trait hooks and handlers
-	oam.RegisterHandlers(oam.STypeComponent, &Handler{name: "comp"})
+	oam.RegisterHandlers(oam.STypeApplicationConfiguration, &Handler{name: "app", client: client})
 
 	// reconcilers must register manualy
 	// cloudnativeapp/oam-runtime/pkg/oam as a pkg should not do os.Exit(), instead of
 	// panic or returning Error could be better
-	err := oam.Run(oam.WithComponent())
+	err = oam.Run(oam.WithApplicationConfiguration())
 	if err != nil {
 		panic(err)
 	}
 }
 
 type Handler struct {
-	name string
+	client *versioned.Clientset
+	name   string
 }
 
 func (s *Handler) Handle(ctx *oam.ActionContext, comp runtime.Object, eType oam.EType) error {
-	component, ok := comp.(*v1alpha1.ComponentSchematic)
+	appConfig, ok := comp.(*v1alpha1.ApplicationConfiguration)
 	if !ok {
 		return errors.New("type mismatch")
 	}
-	fmt.Printf("settings: %s\n", component.Spec.WorkloadSettings.Raw)
-	//Note: this type should be consistent with workloadType
-	settings := make(map[string]interface{})
-	err := json.Unmarshal(component.Spec.WorkloadSettings.Raw, &settings)
-	if err != nil {
-		return err
-	}
-	for k, v := range settings {
-		fmt.Printf("%s: %s\n", k, v)
+	for _, comp := range appConfig.Spec.Components {
+		compIns, err := s.client.CoreV1alpha1().ComponentSchematics(appConfig.Namespace).Get(comp.ComponentName, v1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get component %s err %v", comp.ComponentName, err)
+		}
+		settings, err := common.ExtractParams(comp.ParameterValues, compIns.Spec.WorkloadSettings)
+		if err != nil {
+			return err
+		}
+		for k, v := range settings {
+			fmt.Printf("%s: %s\n", k, v)
+		}
 	}
 	return nil
 }

--- a/pkg/oam/controller.go
+++ b/pkg/oam/controller.go
@@ -89,7 +89,6 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
fixes #16 

In this PR, I mainly support parameter parse in `runtime.RawExtention`. For example workloadSettings is such a case.

Component is like this:

```
apiVersion: core.oam.dev/v1alpha1
kind: ComponentSchematic
metadata:
  name: example-workload
  annotations:
    version: v1.0.0
    description: >
      component schematic that describes extended workload.
spec:
  workloadType: example.com/v1alpha1.ExtentionWorkload
  workloadSettings:
    Protocol: Example
    Type: "[fromParam(PType)]"
```

You can notice `"[fromParam(PType)]"`, this mean the workload can load a parameter with name `PType`.

Then you can write parameterValues in AppConfig like below:

```
apiVersion: core.oam.dev/v1alpha1
kind: ApplicationConfiguration
metadata:
  name: example-app
spec:
  components:
    - componentName: example-workload
      instanceName: demo
      parameterValues:
        - name: PType
          value: demo
```

The type in parameterValues must be `string`.