### PR TITLE
fix: run example failed

### DIFF
--- a/examples/componentschematics.yaml
+++ b/examples/componentschematics.yaml
@@ -7,6 +7,11 @@ spec:
   containers:
     - name: server
       image: nginx:latest
+      resources: 
+        cpu: 
+         required: 100m
+        memory: 
+         required: 128Mi
       ports:
         - name: http
           containerPort: 80


### PR DESCRIPTION
```shell script
# deploy OAM component
kubectl apply -f examples/componentschematics.yaml
The ComponentSchematic "stateless-component" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"core.oam.dev/v1alpha1", "kind":"ComponentSchematic", "metadata":map[string]interface {}{"name":"stateless-component", "namespace":"default", "creationTimestamp":"2020-02-22T14:31:34Z", "generation":1, "uid":"0671b682-5580-11ea-9f7c-005056bc1b59"}, "spec":map[string]interface {}{"containers":[]interface {}{map[string]interface {}{"image":"nginx:latest", "name":"server", "ports":[]interface {}{map[string]interface {}{"containerPort":80, "name":"http", "protocol":"TCP"}}}}, "workloadType":"core.oam.dev/v1alpha1.Server"}}: validation failure list:
spec.containers.resources in body is required
```