### PR TITLE
add 'LatestReadyComponentRevisionName' and 'LatestCreatedComponentRevisionName' in ComponentStatus

### DIFF
--- a/api/v1alpha1/component_schematic_types.go
+++ b/api/v1alpha1/component_schematic_types.go
@@ -262,6 +262,15 @@ type ComponentSpec struct {
 }
 
 type ComponentStatus struct {
+	// LatestReadyComponentRevisionName holds the name of the latest ComponentSchematic revision
+	// that has had its "Ready" condition become "True".
+	// +optional
+	LatestReadyComponentRevisionName string `json:"latestReadyComponentRevisionName,omitempty"`
+
+	// LatestCreatedComponentRevisionName is the last ComponentSchematic revision name that was created from this
+	// ComponentSchematic.
+	// +optional
+	LatestCreatedComponentRevisionName string `json:"latestCreatedComponentRevisionName,omitempty"`
 }
 
 // +genclient

--- a/apis/core.oam.dev/v1alpha1/component_schematic_types.go
+++ b/apis/core.oam.dev/v1alpha1/component_schematic_types.go
@@ -248,6 +248,15 @@ type ComponentSpec struct {
 }
 
 type ComponentStatus struct {
+	// LatestReadyComponentRevisionName holds the name of the latest ComponentSchematic revision
+	// that has had its "Ready" condition become "True".
+	// +optional
+	LatestReadyComponentRevisionName string `json:"latestReadyComponentRevisionName,omitempty"`
+
+	// LatestCreatedComponentRevisionName is the last ComponentSchematic revision name that was created from this
+	// ComponentSchematic.
+	// +optional
+	LatestCreatedComponentRevisionName string `json:"latestCreatedComponentRevisionName,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
add 'LatestReadyComponentRevisionName' and 'LatestCreatedComponentRevisionName' in ComponentStatus for mutable ComponentSchematic